### PR TITLE
Block iframe on linkedin.com

### DIFF
--- a/google_signin_remover.js
+++ b/google_signin_remover.js
@@ -1,14 +1,15 @@
 // Blocking Google's popup script before the HTTP request is made.
 browser.webRequest.onBeforeRequest.addListener(
   () => ({ cancel: true }),
-  { 
+  {
     urls: [
       'https://accounts.google.com/gsi/client/*',
       'https://accounts.google.com/gsi/client?*',
       'https://accounts.google.com/gsi/client',
       'https://static.licdn.com/aero-v1/sc/h/29rdkxlvag0d3cpj96fiilbju', // LinkedIn
+      'https://accounts.google.com/gsi/iframe/select?*',  // also LinkedIn
       ],
-    types: ["script"]  
+    types: ["script"]
   },
   ["blocking"],
 );


### PR DESCRIPTION
Hi, hola, salut,

(hopefully) fixes #4 

I have zero experience with extension dev and I do not know this API. I have not tested this.

I offer it in case you can immediately see that it looks good, in the hope it's a low-effort merge. Feel free to close if it's not this simple.

The aim is to kill this iframe on [https://www.linkedin.com/checkpoint/lg/login](https://www.linkedin.com/checkpoint/lg/login):

```html
<iframe src="https://accounts.google.com/gsi/iframe/select?client_id=990339570472-k6nqn1t ...
```

This pattern does not appear anywhere else on the page. There is also a google button on the page, which I believe will not (and should not) be affected.

